### PR TITLE
Fixed mult() to support non-square matrices.

### DIFF
--- a/Common/MV.js
+++ b/Common/MV.js
@@ -277,22 +277,23 @@ function mult( u, v )
     var result = [];
 
     if ( u.matrix && v.matrix ) {
-        if ( u.length != v.length ) {
-            throw "mult(): trying to add matrices of different dimensions";
-        }
-
-        for ( var i = 0; i < u.length; ++i ) {
-            if ( u[i].length != v[i].length ) {
-                throw "mult(): trying to add matrices of different dimensions";
+        var M = u.length;
+        var N = v.length;
+        var P = v[0].length;
+        
+        // Check that inner dimensions match.
+        for ( var i = 0; i < M; ++i ) {
+            if ( u[i].length != N ) {
+                throw "mult(): dimension mismatch";
             }
         }
 
-        for ( var i = 0; i < u.length; ++i ) {
+        for ( var i = 0; i < M; ++i ) {
             result.push( [] );
 
-            for ( var j = 0; j < v.length; ++j ) {
+            for ( var j = 0; j < P; ++j ) {
                 var sum = 0.0;
-                for ( var k = 0; k < u.length; ++k ) {
+                for ( var k = 0; k < N; ++k ) {
                     sum += u[i][k] * v[k][j];
                 }
                 result[i].push( sum );


### PR DESCRIPTION
The current implementation of mult(), when called on two matrices, checks to see that their dimensions exactly match; that is, that if u is MxN, then v must also be MxN.  Instead, the correct check is to verify that if u is MxN, then v must be NxP, and the result should be an MxP matrix.

I imagine the current implementation is based on an assumption that matrices are always square. However, non-square matrices are useful, for example, for representing all the vertices of a shape.

My change fixes mult() to work correctly with non-square matrices. It still assumes that all rows are the same length in both inputs, even though it's possible to create a list-of-lists with different lengths for the inner lists.
